### PR TITLE
Fixed the evolution loops in evolve-every-level

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5405,10 +5405,7 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, u8 type, u16 evolutionItem)
     
     if(CheckSpeedchoiceOption(EVO_EVERY_LEVEL, EVO_EV_OFF) == FALSE)
     {
-        // use the new level as the seed, not the current one.
-        u32 lv = GetMonData(&gPlayerParty[i], MON_DATA_LEVEL, 0) + 1;
-
-        SeedRng((u32)((personality * species) + (lv * species))); // seed with the pokemon's PID with species and LV.
+        // don't re-seed, just let the RNG roll over
         return NationalPokedexNumToSpecies((Random() % NATIONAL_DEX_COUNT) + 1);
     }
 


### PR DESCRIPTION
## Description
Simply stop re-seeding the RNG every time an evolution happens.